### PR TITLE
Simplify input parsing and fix the tests.

### DIFF
--- a/RK-coeff-opt/rk_opt.m
+++ b/RK-coeff-opt/rk_opt.m
@@ -52,20 +52,17 @@ function rk = rk_opt(s,p,class,objective,varargin)
 %       if set to 1, solve the order conditions first before trying to optimize
 %       (in rare cases, this is helpful for high order methods)
 
-% Parse require, optional and param input values with inputParser
-i_p = inputParser;
-i_p.FunctionName = 'rk_opt';
-
 optional_params = varargin;
-setup_params(s,p,class,objective,i_p,optional_params);
+[np,max_tries,startvec,poly_coeff_ind,poly_coeff_val,...
+    solveorderconditions,writeToFile]= setup_params(optional_params);
 
 
 % New random seed every time
 rand('twister', sum(100*clock)); 
 
 % Open pool of sessions (# is equal to the processors specified in np)
-if i_p.Results.np>1
-    matlabpool('local',i_p.Results.np);
+if np>1
+    matlabpool('local',np);
 end
 
 %Set optimization parameters:
@@ -89,37 +86,37 @@ end
 %and the upper and lower bounds on the unknowns: lb <= x <= ub
 [Aeq,beq,lb,ub] = linear_constraints(s,class);
 
-for i=1:i_p.Results.max_tries
+for i=1:max_tries
     fprintf('Attempt %d\n', i);
 
-    if i_p.Results.np>1
+    if np>1
         % # of starting points for multistart
         nsp = 20;
         n=set_n(s,class);
         
         for i=1:nsp
-            x(i,:)=initial_guess(s,p,class,i_p.Results.startvec);
+            x(i,:)=initial_guess(s,p,class,startvec);
             tpoints = CustomStartPointSet(x);
         end
 
         problem = createOptimProblem('fmincon','x0',x(1,:),'objective', ...
                   @(x) rk_obj(x,class,s,p,objective),'Aeq',Aeq,'beq',beq,...
                   'lb',lb,'ub',ub,'nonlcon',...
-                  @(x) nlc(x,class,s,p,objective,i_p.Results.poly_coeff_ind,...
-                  i_p.Results.poly_coeff_val),'options',opts);
+                  @(x) nlc(x,class,s,p,objective,poly_coeff_ind,...
+                  poly_coeff_val),'options',opts);
 
         ms = MultiStart('Display','final','UseParallel','always');
         [X,FVAL,status,outputg,manyminsg] = run(ms,problem,tpoints);
 
     else
-        x=initial_guess(s,p,class,i_p.Results.startvec);
+        x=initial_guess(s,p,class,startvec);
 
         %Optionally find a feasible (for the order conditions) point to start
-        if i_p.Results.solveorderconditions==1
+        if solveorderconditions==1
             x=fsolve(@(x) oc(x,class,s,p),x,opts);
         end
         
-        [X,FVAL,status]=fmincon(@(x) rk_obj(x,class,s,p,objective),x,[],[],Aeq,beq,lb,ub,@(x) nlc(x,class,s,p,objective,i_p.Results.poly_coeff_ind,i_p.Results.poly_coeff_val),opts);
+        [X,FVAL,status]=fmincon(@(x) rk_obj(x,class,s,p,objective),x,[],[],Aeq,beq,lb,ub,@(x) nlc(x,class,s,p,objective,poly_coeff_ind,poly_coeff_val),opts);
     end
     
     % Check order of the scheme
@@ -137,7 +134,7 @@ for i=1:i_p.Results.max_tries
     end
 end 
 
-if (i==i_p.Results.max_tries && status<=0)
+if (i==max_tries && status<=0)
     fprintf('Failed to find a solution.\n')
     rk = -1;
     return
@@ -148,29 +145,32 @@ fprintf('The method found has order of accuracy: %d \n', order)
 if strcmp(objective,'ssp')
     rk.r = -FVAL;
 else
-   % rk.r=am_radius(rk.A,rk.b,rk.c);
+    rk.r=am_radius(rk.A,rk.b,rk.c);
 end
 rk.errcoeff=errcoeff(rk.A,rk.b,rk.c,order);
 [rk.v,rk.alpha,rk.beta] = optimal_shuosher_form(rk.A,rk.b,rk.c);
     
-if (i_p.Results.writeToFile == 1 && p == order)
+if (writeToFile == 1 && p == order)
     output=writeFile(rk,p);
 end
 
-if i_p.Results.np>1 matlabpool close; end
+if np>1 matlabpool close; end
 end
 % =========================================================================
 
 
 % =========================================================================
-function pop_i_p= setup_params(s,p,class,objective,i_p,optional_params)
-%function pop_i_p= setup_params(s,p,class,objective,optional_params,i_p)
+
+function [np,max_tries,startvec,poly_coeff_ind,poly_coeff_val,...
+    solveorderconditions,writeToFile]= setup_params(optional_params);
+%function [np,max_tries,startvec,poly_coeff_ind,poly_coeff_val,...
+%    solveorderconditions,writeToFile]= setup_params(optional_params);
 %
 % Set default optional and param values
 
-% Expected values or string
-expected_classes = {'erk','irk','dirk','sdirk','2S','2Sstar','3Sstar'};
-expected_objectives = {'ssp','acc'};
+i_p = inputParser;
+i_p.FunctionName = 'setup_params';
+
 expected_startvec = {'random','smart'};
 expected_solveorderconditions = [0,1];
 
@@ -183,27 +183,26 @@ default_np = 1;
 default_max_tries = 10;
 default_writeToFile = 1;
 
-
 % Populate input parser object
 % ----------------------------
-% Required values
-i_p.addRequired('s',@isnumeric);
-i_p.addRequired('p',@isnumeric);
-i_p.addRequired('class',@(x) ischar(x) && any(validatestring(x,expected_classes)));
-i_p.addRequired('objective',@(x) ischar(x) && any(validatestring(x,expected_objectives)));
-
-% Optional values
+% Parameter values
 i_p.addParamValue('poly_coeff_ind',default_poly_coeff_ind,@isnumeric); 
 i_p.addParamValue('poly_coeff_val',default_poly_coeff_val,@isnumeric);
-i_p.addParamValue('startvec',default_startvec,@(x) ischar(x) && any(validatestring(x,expected_startvec)));
+i_p.addParamValue('startvec',default_startvec);
 i_p.addParamValue('solveorderconditions',default_solveorderconditions,@(x) isnumeric(x) && any(x==expected_solveorderconditions))
 i_p.addParamValue('np',default_np,@isnumeric);
 i_p.addParamValue('max_tries',default_max_tries,@isnumeric);
 i_p.addParamValue('writeToFile',default_writeToFile,@isnumeric);
 
-% Parse input arguments
-i_p.parse(s,p,class,objective,optional_params{:});
+i_p.parse(optional_params{:});
 
+np                   = i_p.Results.np;
+max_tries            = i_p.Results.max_tries;
+startvec             = i_p.Results.startvec;
+poly_coeff_ind       = i_p.Results.poly_coeff_ind;
+poly_coeff_val       = i_p.Results.poly_coeff_val;
+solveorderconditions = i_p.Results.solveorderconditions;
+writeToFile          = i_p.Results.writeToFile;
 end
 % =========================================================================
 

--- a/RK-coeff-opt/test/test_rkopt.m
+++ b/RK-coeff-opt/test/test_rkopt.m
@@ -10,7 +10,7 @@ initTestSuite;
 % =============================================================
 function test_SSP32
 tol = 1.e-14;
-rk=rk_opt(3,2,'erk','ssp',[],[],'smart');
+rk=rk_opt(3,2,'erk','ssp','startvec','smart');
 A = [0 0 0; 0.5 0 0; 0.5 0.5 0];
 r = 2.;
 
@@ -19,7 +19,7 @@ assertElementsAlmostEqual(rk.A,A);
 
 
 function test_SSP43
-rk=rk_opt(4,3,'erk','ssp',[],[],'smart');
+rk=rk_opt(4,3,'erk','ssp','startvec','smart');
 b = [1./6 1./6 1./6 1./2]';
 r = 2.;
 
@@ -28,7 +28,7 @@ assertElementsAlmostEqual(rk.b,b);
 
 
 function test_SDIRK_SSP22
-rk=rk_opt(2,2,'sdirk','ssp',[],[],'random');
+rk=rk_opt(2,2,'sdirk','ssp','startvec','random');
 b = [1./2 1./2]';
 r = 4.;
 
@@ -38,7 +38,7 @@ assertElementsAlmostEqual(rk.b,b);
 
 function test_DIRK_SSP22
 tol = 1.e-7;
-rk=rk_opt(2,2,'dirk','ssp',[],[],'smart');
+rk=rk_opt(2,2,'dirk','ssp','startvec','smart');
 
 b = [1./2 1./2]';
 r = 4.;
@@ -50,7 +50,7 @@ end
 
 function test_RK22_acc
 x=[0.117831902493812 0.187227391881097   0.812772608118903  -0.099952256513284 -0.010000000000000];
-rk=rk_opt(2,2,'erk','acc',[],[],x);
+rk=rk_opt(2,2,'erk','acc','startvec',x);
 b = [0.25 0.75]';
 
 assertElementsAlmostEqual(rk.errcoeff,1./6);
@@ -63,7 +63,7 @@ assertElementsAlmostEqual(rk.b,b,'absolute',1.e-5);
 % ====================================================================
 function test_SSP32_multistart
 tol = 1.e-14;
-rk=rk_opt(3,2,'erk','ssp',[],[],'smart',0,1);
+rk=rk_opt(3,2,'erk','ssp','startvec','smart');
 A = [0 0 0; 0.5 0 0; 0.5 0.5 0];
 r = 2.;
 
@@ -73,7 +73,7 @@ assertElementsAlmostEqual(rk.A,A);
 
 function test_SSP32_multistart_parallel
 tol = 1.e-14;
-rk=rk_opt(3,2,'erk','ssp',[],[],'smart',0,2);
+rk=rk_opt(3,2,'erk','ssp','startvec','smart','np',2);
 A = [0 0 0; 0.5 0 0; 0.5 0.5 0];
 r = 2.;
 
@@ -82,7 +82,7 @@ assertElementsAlmostEqual(rk.A,A);
 
 
 function test_SSP43_multistart
-rk=rk_opt(4,3,'erk','ssp',[],[],'smart',0,1);
+rk=rk_opt(4,3,'erk','ssp','startvec','smart','np',1);
 b = [1./6 1./6 1./6 1./2]';
 r = 2.;
 
@@ -91,7 +91,7 @@ assertElementsAlmostEqual(rk.b,b);
 
 
 function test_SSP43_multistart_parallel
-rk=rk_opt(4,3,'erk','ssp',[],[],'smart',0,2);
+rk=rk_opt(4,3,'erk','ssp','startvec','smart','np',2);
 b = [1./6 1./6 1./6 1./2]';
 r = 2.;
 
@@ -100,7 +100,7 @@ assertElementsAlmostEqual(rk.b,b);
 
 
 function test_SDIRK_SSP22_multistart
-rk=rk_opt(2,2,'sdirk','ssp',[],[],'random',0,1);
+rk=rk_opt(2,2,'sdirk','ssp','startvec','random','np',1);
 b = [1./2 1./2]';
 r = 4.;
 
@@ -109,7 +109,7 @@ assertElementsAlmostEqual(rk.b,b);
 
 
 function test_SDIRK_SSP22_multistart_parallel
-rk=rk_opt(2,2,'sdirk','ssp',[],[],'random',0,2);
+rk=rk_opt(2,2,'sdirk','ssp','startvec','random','np',2);
 b = [1./2 1./2]';
 r = 4.;
 
@@ -119,7 +119,7 @@ assertElementsAlmostEqual(rk.b,b);
 
 function test_DIRK_SSP22_multistart
 tol = 1.e-7;
-rk=rk_opt(2,2,'dirk','ssp',[],[],'smart',0,1);
+rk=rk_opt(2,2,'dirk','ssp','startvec','smart','np',1);
 
 b = [1./2 1./2]';
 r = 4.;
@@ -131,7 +131,7 @@ end
 
 function test_DIRK_SSP22_multistart_parallel
 tol = 1.e-7;
-rk=rk_opt(2,2,'dirk','ssp',[],[],'smart',0,2);
+rk=rk_opt(2,2,'dirk','ssp','startvec','smart','np',2);
 
 b = [1./2 1./2]';
 r = 4.;
@@ -143,7 +143,7 @@ end
 
 function test_RK22_acc_multistart
 x=[0.117831902493812 0.187227391881097   0.812772608118903  -0.099952256513284 -0.010000000000000];
-rk=rk_opt(2,2,'erk','acc',[],[],x,0,1);
+rk=rk_opt(2,2,'erk','acc','startvec',x,'np',1);
 b = [0.25 0.75]';
 
 assertElementsAlmostEqual(rk.errcoeff,1./6);
@@ -152,7 +152,7 @@ assertElementsAlmostEqual(rk.b,b,'absolute',1.e-5);
 
 function test_RK22_acc_multistart_parallel
 x=[0.117831902493812 0.187227391881097   0.812772608118903  -0.099952256513284 -0.010000000000000];
-rk=rk_opt(2,2,'erk','acc',[],[],x,0,2);
+rk=rk_opt(2,2,'erk','acc','startvec',x,'np',2);
 b = [0.25 0.75]';
 
 assertElementsAlmostEqual(rk.errcoeff,1./6);


### PR DESCRIPTION
Now we only parse the parameter arguments.

All the tests were broken by the last commit; this fixes them to use the new input format.
