### PR TITLE
minor spelling, grammar, formatting fixes

### DIFF
--- a/RK-coeff-opt/rk_opt.m
+++ b/RK-coeff-opt/rk_opt.m
@@ -31,20 +31,20 @@ function rk = rk_opt(s,p,class,objective,varargin)
 %
 %     .. note::
 %        **numerical experiments have shown that when the objective function is the minimization of the leading truncation error coefficient, the interior-point algorithm performs much better than the sqp one.**
-%     
+%
 %     * display: level of display of fmincon solver ('off', 'iter', 'notify' or 'final'). The default value is 'notify'.
 %     * problem_class: class of problems for which the RK is designed ('linear' or 'nonlinear' problems). This option changes the type of order conditions check, i.e. linear or nonlinear order conditions controll. The default value is 'nonlinear'.
-% 
-% 
+%
+%
 % .. note::
-% 
+%
 %    Only :math:`s`: , :math:`p`: , class and objective are required inputs.
-%    All the other arguments are **parameter name - value arguments to the input 
+%    All the other arguments are **parameter name - value arguments to the input
 %    parser scheme**. Therefore they can be specified in any order.
 %
 %    **Example**::
-% 
-%     >>> rk=rk_opt(4,3,'erk','acc','max_tries',2,'np',1,'solveorderconditions',1)
+%
+%     >> rk=rk_opt(4,3,'erk','acc','max_tries',2,'np',1,'solveorderconditions',1)
 %
 % The fmincon options are set through the **optimset** that creates/alters optimization options structure. By default the following additional options are used:
 %     * MaxFunEvals = 1000000
@@ -62,7 +62,7 @@ function rk = rk_opt(s,p,class,objective,varargin)
     setup_params(varargin);
 
 % New random seed every time
-rand('twister', sum(100*clock)); 
+rand('twister', sum(100*clock));
 
 % Open pool of sessions (# is equal to the processors specified in np)
 if np>1
@@ -77,7 +77,7 @@ options=optimset('MaxFunEvals',1000000,'TolCon',1.e-13,'TolFun',1.e-13,'TolX',1.
 %,'RelLineSrchBnd',0.1,'RelLineSrchBndDuration',100000000);
 %Also, sometimes something can be gained by adjusting 'Tol*' above.
 %==============================================
- 
+
 if strcmp(objective,'ssp')
     opts = optimset(options,'GradObj','on');
 elseif strcmp(objective,'acc')
@@ -85,7 +85,7 @@ elseif strcmp(objective,'acc')
 else
     error('Unrecognized objective type.');
 end
-                 
+
 %Set the linear constraints: Aeq*x = beq
 %and the upper and lower bounds on the unknowns: lb <= x <= ub
 [Aeq,beq,lb,ub] = linear_constraints(s,class,objective,k);
@@ -96,7 +96,7 @@ for i=1:max_tries
     if np>1
         % # of starting points for multistart
         nsp = 20;
-        
+
         for i=1:nsp
             x(i,:) = initial_guess(s,p,class,startvec,k);
             tpoints = CustomStartPointSet(x);
@@ -120,11 +120,11 @@ for i=1:max_tries
         end
 
         [X,FVAL,status] = fmincon(@(x) rk_obj(x,class,s,p,objective),...
-                                x,[],[],Aeq,beq,lb,ub,...  
+                                x,[],[],Aeq,beq,lb,ub,...
                                 @(x) nonlinear_constraints(x,class,s,p,objective,poly_coeff_ind,poly_coeff_val,k),opts);
     end
 
-  
+
     % Check order of the scheme
     if (class(1:2)=='2S' | class(1:2)=='3S')
         [rk.A,rk.b,rk.bhat,rk.c,rk.alpha,rk.beta,rk.gamma1,rk.gamma2,rk.gamma3,rk.delta] = unpack_lsrk(X,s,class);
@@ -136,7 +136,7 @@ for i=1:max_tries
         [rk.A,rk.Ahat,rk.b,rk.bhat,rk.rk.D,rk.theta] = unpack_msrk(X,s,k,class);
         order = p; %HACK
     end
-    
+
     % Compute properties of the method
     if strcmp(objective,'ssp')
         rk.r = -FVAL;
@@ -149,7 +149,7 @@ for i=1:max_tries
         fprintf('The method found has order of accuracy: %d \n', order)
         break;
     end
-end 
+end
 
 if (i==max_tries && status<=0)
     fprintf('Failed to find a solution.\n')
@@ -162,7 +162,7 @@ if k==1
 
     if strcmp(objective,'ssp')
         [rk.v_opt,rk.alpha_opt,rk.beta_opt] = optimal_shuosher_form(rk.A,rk.b,rk.c);
-    
+
     if (write_to_file == 1 && p == order)
         output = write_file(rk,p);
     end
@@ -206,9 +206,9 @@ default_problem_class = 'nonlinear';
 % Populate input parser object
 % ----------------------------
 % Parameter values
-i_p.addParamValue('k',1,@isnumeric); 
-i_p.addParamValue('min_amrad',0,@isnumeric); 
-i_p.addParamValue('poly_coeff_ind',[],@isnumeric); 
+i_p.addParamValue('k',1,@isnumeric);
+i_p.addParamValue('min_amrad',0,@isnumeric);
+i_p.addParamValue('poly_coeff_ind',[],@isnumeric);
 i_p.addParamValue('poly_coeff_val',[],@isnumeric);
 i_p.addParamValue('startvec',default_startvec);
 i_p.addParamValue('solveorderconditions',default_solveorderconditions,@(x) isnumeric(x) && any(x==expected_solveorderconditions))
@@ -252,8 +252,8 @@ switch class
         %Explicit Runge-Kutta
         switch starttype
             case 'random'
-                x(1:s-1)=sort(rand(1,s-1)-1/2); 
-                x(s:2*s-2)=rand(1,s-1)-1/2; 
+                x(1:s-1)=sort(rand(1,s-1)-1/2);
+                x(s:2*s-2)=rand(1,s-1)-1/2;
                 x(2*s-1)=1-sum(x(s:2*s-2));
                 x(2*s:2*s-1+s*(s-1)/2)=rand(1,s*(s-1)/2)-1/2;
                 x(2*s+s*(s-1)/2)=-0.01;
@@ -270,8 +270,8 @@ switch class
         % Implicit Runge-Kutta
         switch starttype
             case 'random'
-                x(1:s)=sort(rand(1,s)); 
-                x(s+1:2*s-1)=rand(1,s-1); 
+                x(1:s)=sort(rand(1,s));
+                x(s+1:2*s-1)=rand(1,s-1);
                 x(2*s)=1-sum(x(s+1:2*s-1));
                 x(2*s+1:2*s+s^2)=rand(1,s^2);
                 x(2*s+s^2+1)=-0.01;
@@ -293,7 +293,7 @@ switch class
             case 'random'
                 x(1:s-1)=sort(rand(1,s-1));    %c's
                 x(s:2*s-2)=rand(1,s-1);        %b's
-                x(2*s-1)=1-sum(x(s:2*s-2)); 
+                x(2*s-1)=1-sum(x(s:2*s-2));
                 x(2*s:2*s-1+s*(s-1))=rand(1,s*(s-1));  %A's
                 x(2*s+s*(s-1))=-0.01;            %r
             case 'smart'
@@ -343,7 +343,7 @@ switch class
                 nbz=4;
                 %modified 2nd order
                 x(1:s-1)=(1:s-1)/s;
-                x(s:2*s-1)=1/(s-nbz);  
+                x(s:2*s-1)=1/(s-nbz);
                 %Zero some b's:
                 x(2*s-nbz:2*s-1)=0;
                 x(s)=x(s)/2;
@@ -386,8 +386,8 @@ end
 function wf=write_file(rk,p)
 %function wf=write_file(rk,p)
 %
-% 
-% Write to file Butcher's coefficients and low-storage coefficients if 
+%
+% Write to file Butcher's coefficients and low-storage coefficients if
 % required.
 
 szA = size(rk.A);

--- a/RKtools/am_radius.m
+++ b/RKtools/am_radius.m
@@ -13,11 +13,15 @@ function r = am_radius(A,b,c,eps,rmax)
 %
 % The radius of absolute monotonicity is the largest value of `r`
 % such that
-% \\begin{eqnarray}
-% K(I+rA)^{-1} &     \\ge & 0 \\\\
-% rK(I+rA)^{-1}e_m & \\le & e_{m+1} 
-% \\end{eqnarray}
-% where $$ K = \\left(\\begin{array}{c} A \\\\ b^T \\end{array}\\right) $$
+%
+% .. raw:: latex
+%
+%    \begin{eqnarray}
+%    K(I+rA)^{-1} \ge & 0    \\
+%    rK(I+rA)^{-1}e_m \le & e_{m+1}
+%    \end{eqnarray}
+%
+%    where $$ K = \left(\begin{array}{c} A \\ b^T \end{array}\right) $$
 
 
 if nargin<5 rmax=50; end

--- a/RKtools/rk_stabfun.m
+++ b/RKtools/rk_stabfun.m
@@ -8,7 +8,10 @@ function [p,q] = rk_stabfun(rk)
 %
 % q contains the coefficients of the denominator
 %
-% $$\\phi(z)=\\frac{\\sum_j p_j z^j}{\\sum_j q_j z^j} = \\frac{\\det(I-z(A+eb^T))}{\\det(I-zA)}.$$
+%
+% .. raw:: latex
+%
+%     $$\phi(z)=\frac{\sum_j p_j z^j}{\sum_j q_j z^j} = \frac{\det(I-z(A+eb^T))}{\det(I-zA)}.$$
 
 s = length(rk.b);
 e=ones(s,1);

--- a/doc/RK-coeff-opt.rst
+++ b/doc/RK-coeff-opt.rst
@@ -202,7 +202,7 @@ The meaning of the arguments is as follows:
 
     .. note::
        **numerical experiments have shown that when the objective function is the minimization of the leading truncation error coefficient, the interior-point algorithm performs much better than the sqp one.**
-    
+
     * display: level of display of fmincon solver ('off', 'iter', 'notify' or 'final'). The default value is 'notify'.
     * problem_class: class of problems for which the RK is designed ('linear' or 'nonlinear' problems). This option changes the type of order conditions check, i.e. linear or nonlinear order conditions controll. The default value is 'nonlinear'.
 
@@ -210,12 +210,12 @@ The meaning of the arguments is as follows:
 .. note::
 
    Only :math:`s`: , :math:`p`: , class and objective are required inputs.
-   All the other arguments are **parameter name - value arguments to the input 
+   All the other arguments are **parameter name - value arguments to the input
    parser scheme**. Therefore they can be specified in any order.
 
    **Example**::
 
-    >>> rk=rk_opt(4,3,'erk','acc','max_tries',2,'np',1,'solveorderconditions',1)
+    >> rk=rk_opt(4,3,'erk','acc','max_tries',2,'np',1,'solveorderconditions',1)
 
 The fmincon options are set through the **optimset** that creates/alters optimization options structure. By default the following additional options are used:
     * MaxFunEvals = 1000000

--- a/doc/RKtools.rst
+++ b/doc/RKtools.rst
@@ -26,11 +26,15 @@ the default value of rmax to be increased.
 
 The radius of absolute monotonicity is the largest value of `r`
 such that
-\\begin{eqnarray}
-K(I+rA)^{-1} &     \\ge & 0 \\\\
-rK(I+rA)^{-1}e_m & \\le & e_{m+1} 
-\\end{eqnarray}
-where $$ K = \\left(\\begin{array}{c} A \\\\ b^T \\end{array}\\right) $$
+
+.. raw:: latex
+
+   \begin{eqnarray}
+   K(I+rA)^{-1} \ge & 0    \\
+   rK(I+rA)^{-1}e_m \le & e_{m+1}
+   \end{eqnarray}
+
+   where $$ K = \left(\begin{array}{c} A \\ b^T \end{array}\right) $$
 
 
 
@@ -135,7 +139,10 @@ p contains the coefficients of the numerator
 
 q contains the coefficients of the denominator
 
-$$\\phi(z)=\\frac{\\sum_j p_j z^j}{\\sum_j q_j z^j} = \\frac{\\det(I-z(A+eb^T))}{\\det(I-zA)}.$$
+
+.. raw:: latex
+
+    $$\phi(z)=\frac{\sum_j p_j z^j}{\sum_j q_j z^j} = \frac{\det(I-z(A+eb^T))}{\det(I-zA)}.$$
 
 
 

--- a/doc/future.rst
+++ b/doc/future.rst
@@ -8,4 +8,5 @@ routines for the RK-coeff-opt package.  These will use OpenOpt and in
 particular Ipopt.
 
 Additionally, we have bits of code for the following that will be merged in to the main package:
+
     * Optimization of coefficients for Runge-Kutta schemes with downwinding

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,36 +3,41 @@ Overview
 ********
 
 `RK-opt <https://github.com/ketch/RK-opt>`_ is a MATLAB package for designing
-Runge-Kutta (RK) methods and stability polynomials.  
+Runge-Kutta (RK) methods and stability polynomials.
 Supported objective functions include the principal
 error norm and the SSP coefficient.  Supported constraints include stability
 polynomial coefficients, low-storage formulations, and structural constraints
 (explicit, diagonally implicit, etc.)
 RK-opt uses MATLAB's optimization toolbox, in particular *fmincon* and *linprog*.
 
-MATLAB's global optimization toolbox function *Multistart* can be used to exploit the 
+MATLAB's global optimization toolbox function *Multistart* can be used to exploit the
 benefits of parallel search on multicore machines.
 
 
-The RK-Opt pacakge consists of the following packages:
-    * **RK-coeff-opt**: Find optimal Runge-Kutta method coefficients, for a prescribed order of accuracy and number of stages.  
+The RK-Opt package consists of the following packages:
+    + **RK-coeff-opt**:
+                        Find optimal Runge-Kutta method coefficients for a prescribed order of accuracy and number of stages.
                         The objective function
                         can be chosen as either the **SSP coefficient** or the
                         **leading truncation error coefficient**.
                         The method may be constrained to have a **low-storage implementation**
                         and/or a prescribed **stability polynomial**.
                         Implicit and diagonally implicit methods can also be optimized.
-    * **am_rad-opt**: Find stability functions with optimal radius of absolute monotonicity.
-                        This includes codes for optimizing stability functions of 
+    + **am_rad-opt**:
+                        Find stability functions with optimal radius of absolute monotonicity.
+                        This includes codes for optimizing stability functions of
                         multistep, multistage methods and even methods with downwinding.
                         The optimization of rational functions is experimental.
-    * **polyopt**:    Given a spectrum (typically corresponding to a spatial
-                        semi-discretization of a PDE), finds an optimal stability
-                        polynomial.  The polynomial coefficients can then be used
+    + **polyopt**:
+                        Given a spectrum (typically corresponding to a spatial
+                        semi-discretization of a PDE), find an optimal stability
+                        polynomial in terms of its coefficients.  These polynomial
+                        coefficients can then be used
                         as input to **RK-coeff-opt** to find a corresponding Runge-Kutta
                         method.
-    * **RKtools**:    Some general utilities for analyzing Runge-Kutta methods.
-                        
+    + **RKtools**:
+                        Some general utilities for analyzing Runge-Kutta methods.
+
 If you use RK-Opt in published work, please cite this manual and/or relevant papers from the bibliography
 below.
 
@@ -66,7 +71,7 @@ organized by subpackage.
 Contributing
 -------------
 If you wish to contribute, we recommend that you
-fork the RK-Opt Github repository, implement your additions, and issue
-a pull request.  You may also simply e-mail a patch to us.
-
-
+fork the `RK-Opt GitHub repository <https://github.com/ketch/RK-opt>`_,
+implement your additions, and `issue a pull request
+<https://help.github.com/articles/using-pull-requests>`_.  You may also
+simply e-mail a patch to us.

--- a/doc/started.rst
+++ b/doc/started.rst
@@ -6,7 +6,7 @@ Installation
 ===============
 This section describes how to obtain RK-opt and test that it is working correctly.
 
-Dependencies 
+Dependencies
 ------------
  - MATLAB 7.X or greater
  - MATLAB optimization toolbox
@@ -16,45 +16,45 @@ Optional dependencies
  - MATLAB Global Optimization toolbox (for multicore search)
  - xUnit test framework (for testing your installation); available for free
    from `<http://www.mathworks.com/matlabcentral/fileexchange/22846>`_.
-   xUnit requires MATLAB R2008a or later. 
+   xUnit requires MATLAB R2008a or later.
 
 
 Obtaining RK-opt
 ------------------
- - Download: https://github.com/ketch/RK-opt/downloads.  
+ - Download: https://github.com/ketch/RK-opt/downloads.
  - Or clone::
 
     $ git clone https://github.com/ketch/RK-opt.git
 
-After unzipping/cloning, add the subdirectory `RK-opt/RKtools` to your MATLAB path.
+After unzipping/cloning, add the subdirectory ``RK-opt/RKtools`` to your MATLAB path.
 
 
 =========================
-Testing your installation 
+Testing your installation
 =========================
-You can test your RK-opt installation with xUnit.  
+You can test your RK-opt installation with xUnit.
 
 Installing xUnit
 ----------------
 The MATLAB xUnit test framework can be downloaded for free at
 `<http://www.mathworks.com/matlabcentral/fileexchange/22846>`_
-(after the link, click on the button in the upper right corner). 
+(after the link, click on the button in the upper right corner).
 An easy way to install xUnit without setting any environment variables is
-to add the following lines to your **startup.m** file:
+to add the following lines to your ``startup.m`` file:
 
 .. doctest::
 
-   addpath "path-to-matlab_xunit_3"/matlab_xunit
-   addpath "path-to-matlab_xunit_3"/matlab_xunit/xunit
-   addpath "path-to-RK-opt"/RK-coeff-opt
+   addpath /path/to/matlab/xunit/matlab_xunit
+   addpath /path/to/matlab/xunit/matlab_xunit/xunit
+   addpath /path/to/RK-opt/RK-coeff-opt
 
 Running the tests
 -----------------
 
 To run the tests, do the following in MATLAB::
 
-    >>> cd "path-to-RK-Opt"/general/test
-    >>> runtests
+    >> cd /path/to/RK/Opt/general/test
+    >> runtests
 
-If everything is set up correctly, this will run several tests, and inform you 
+If everything is set up correctly, this will run several tests, and inform you
 that the tests passed. At present the tests are not very extensive.


### PR DESCRIPTION
Lots of minor fixes sprinkled throughout the files:

M-file docstrings
rk_opt.m     - Python >>> to MATLAB >>
am_radius.m  - RST LaTeX formatting of equations
rk_stabfun.m - RST LaTeX formmating of equations

RST-file documentation
index.rst    - RST formatting for description list
               pacakge spelling fix
future.rst   - Better GitHub links
started.rst  - RST formatting ` `to`` ``
               Path changes to make addpath call clearer
               Python >>> to MATLAB >>

Updates to generated files
RK-coeff-opt.rst - see changes to .m files
RKtools.rst      - see changes to .m files
