### PR TITLE
remove superfluous `A=zeros(s);`

### DIFF
--- a/RK-coeff-opt/unpack_lsrk.m
+++ b/RK-coeff-opt/unpack_lsrk.m
@@ -6,7 +6,6 @@ function [A,Ahat,b,bhat,c,chat,alpha,beta,gamma1,gamma2,gamma3,delta]=unpack_lsr
 % This function also returns the low-storage coefficients.
 
 gamma3=[];
-A=zeros(s);
 switch class
   case '2S'
     % n = 3s - 3 free parameters


### PR DESCRIPTION
@mparsani reported a problem with the changes of #40. Here, I try to fix this by removing a superfluous line of code.

I did some local tests before opening #40 on my workstation and my notebook with two different versions of MATLAB and didn't notice any problems. However, I hope that this fixes the problems with other versions of MATLAB.